### PR TITLE
Rename the credentials to use "local" explicitly

### DIFF
--- a/n8n/backup/credentials/sFfERYppMeBnFNeA.json
+++ b/n8n/backup/credentials/sFfERYppMeBnFNeA.json
@@ -2,7 +2,7 @@
   "createdAt": "2024-02-23T16:27:55.919Z",
   "updatedAt": "2024-02-23T16:27:55.918Z",
   "id": "sFfERYppMeBnFNeA",
-  "name": "QdrantApi account",
+  "name": "Local QdrantApi database",
   "data": "U2FsdGVkX18bm81Pk18TjmfyKEIbzd91Dt1O8pUPgTxVGk5v1mXp7MlE/3Fl+NHGTMBqa3u7RBS36wTQ74rijQ==",
   "type": "qdrantApi",
   "nodesAccess": [

--- a/n8n/backup/credentials/xHuYe0MDGOs9IpBW.json
+++ b/n8n/backup/credentials/xHuYe0MDGOs9IpBW.json
@@ -2,7 +2,7 @@
   "createdAt": "2024-02-23T16:26:54.475Z",
   "updatedAt": "2024-02-23T16:26:58.928Z",
   "id": "xHuYe0MDGOs9IpBW",
-  "name": "Ollama account",
+  "name": "Local Ollama service",
   "data": "U2FsdGVkX18BVmjQBCdNKSrjr0GhmcTwMgG/rSWhncWtqOLPT62WnCIktky8RgM1PhH7vMkMc5EuUFIQA/eEZA==",
   "type": "ollamaApi",
   "nodesAccess": [

--- a/n8n/backup/workflows/srOnR8PAY3u4RSwb.json
+++ b/n8n/backup/workflows/srOnR8PAY3u4RSwb.json
@@ -44,7 +44,7 @@
       "credentials": {
         "ollamaApi": {
           "id": "xHuYe0MDGOs9IpBW",
-          "name": "Ollama account"
+          "name": "Local Ollama service"
         }
       }
     }


### PR DESCRIPTION
This makes it clear that this is for the local instances specifically, not for any cloud instances.

https://linear.app/n8n/issue/AI-290/rename-preloaded-credentials